### PR TITLE
Remove unmaintained dependency and use the secret scanning example payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Each example is in a separate directory, first level directories are the languag
 - [`go`](go/)
 - [`java`](java/)
 - [`javascript`](javascript/)
+- [`php`](php/)
 - [`python/cyrptodome`](python/cryptodome/)
 - [`python/ecdsa`](python/ecdsa)
 - [`ruby`](ruby/)

--- a/php/README.md
+++ b/php/README.md
@@ -1,6 +1,6 @@
 # Signature Verification in php
 
-This is a simple example of how to verify a signature in php. It uses mdanter's ecc library to do so.
+This is a simple example of how to verify a signature in php. It uses the `openssl_verify` function to verify the signature.
 
 ## Usage
 

--- a/php/README.md
+++ b/php/README.md
@@ -1,4 +1,4 @@
-# Signature Verification in javascript
+# Signature Verification in php
 
 This is a simple example of how to verify a signature in php. It uses mdanter's ecc library to do so.
 
@@ -6,18 +6,9 @@ This is a simple example of how to verify a signature in php. It uses mdanter's 
 
 To run the example you can run:
 
-```
+```bash
 composer update
 php verify.php
 ```
 
-Note that the example as written will fail. You will need to replace:
-
-```php
-$signature = 'base64-encoded-signature';
-$publicKey = 'public-key-identifier';
-$githubToken = 'your-github-token';
-$payload = 'payload-data';
-```
-
-with actual values obtained from a Copilot request in order for the example to work. 
+[`verify.php`](verify.php) contains an example of how to verify the signature.

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,5 @@
 {
     "require": {
-        "guzzlehttp/guzzle": "^7.0",
-        "mdanter/ecc": "^0.5.0"
+        "guzzlehttp/guzzle": "^7.0"
     }
 }


### PR DESCRIPTION
This pull request removes the unmaintained dependency [`mdanter/ecc`](https://packagist.org/packages/mdanter/ecc) and uses the secret scanning example payload.

---

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17): Added a link to the new PHP example directory.
* [`php/README.md`](diffhunk://#diff-0904968a353eb8d4371a79061da46def9920fddd1a6b43c1f3523c08a22db6d1L1-R14): Updated the description to reflect the use of `openssl_verify` instead of `mdanter's ecc` library.

Code simplification:

* [`php/composer.json`](diffhunk://#diff-f1cfda93f99b08c29af2c4ec56843af7864d017629ef4d7c881f6bcd7e85f3bfL3-R3): Removed the `mdanter/ecc` dependency as it is no longer needed.
* [`php/verify.php`](diffhunk://#diff-a4c406f97db9366d8d493564394d9144c9bd01be6b54deab5c8149e8942c7406L6-R25): Replaced the custom ECC signature verification logic with the `openssl_verify` function, simplifying the code and reducing dependencies. [[1]](diffhunk://#diff-a4c406f97db9366d8d493564394d9144c9bd01be6b54deab5c8149e8942c7406L6-R25) [[2]](diffhunk://#diff-a4c406f97db9366d8d493564394d9144c9bd01be6b54deab5c8149e8942c7406L39-R58)